### PR TITLE
[ADD] vuestorefront: address, order, payment

### DIFF
--- a/vuestorefront/README.rst
+++ b/vuestorefront/README.rst
@@ -22,6 +22,24 @@ forked module:
 * implemented ``products`` ``category_slug`` filter.
 * moved Product schema domain method to ``product.template`` to be extendable.
 
+Addresses
+---------
+
+* Moved address domain methods on ``res.partner`` to be extendable.
+* Moved preparation of partner (address) creation/update on ``res.partner to
+  be extendable.
+
+Sale Order
+----------
+
+* Added UpdateOrder mutation to be able to update some data on sale order.
+
+Payments
+--------
+
+* Added MakePayment mutation to be handler for all payments. Currently transfer
+  payment is supported.
+
 Login
 =====
 

--- a/vuestorefront/models/__init__.py
+++ b/vuestorefront/models/__init__.py
@@ -4,8 +4,10 @@
 
 from . import invalidate_cache
 from . import website
+from . import res_partner
 from . import product_public_category
 from . import product_template
 from . import product_product
 from . import res_config_settings
 from . import res_users
+from . import sale_order

--- a/vuestorefront/models/res_partner.py
+++ b/vuestorefront/models/res_partner.py
@@ -1,0 +1,54 @@
+from odoo import models, api
+from odoo.osv import expression
+
+VSF_ADDRESS_DIRECT_FIELDS = [
+    'name', ''
+]
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def prepare_vsf_address_direct_fields(self):
+        return [
+            "name",
+            "street",
+            "street2",
+            "phone",
+            "zip",
+            "city",
+            "state_id",
+            "country_id",
+            "email",
+        ]
+
+    @api.model
+    def prepare_vsf_address_vals(self, address):
+        vals = {}
+        for fname in self.prepare_vsf_address_direct_fields():
+            if fname in address:
+                vals[fname] = address[fname]
+        return vals
+
+    def prepare_vsf_invoice_address_domain(self):
+        self.ensure_one()
+        return [("type", "=", "invoice")]
+
+    def prepare_vsf_delivery_address_domain(self):
+        self.ensure_one()
+        return [("type", "=", "delivery")]
+
+    def _prepare_vsf_base_address_domain(self):
+        self.ensure_one()
+        return [("id", "child_of", self.commercial_partner_id.ids)]
+
+    def _prepare_vsf_address_domain(self, address_types):
+        self.ensure_one()
+        base_domain = self._prepare_vsf_base_address_domain()
+        types = [at.value for at in address_types]
+        type_domains = []
+        for addr_type in types:
+            method_name = f"prepare_vsf_{addr_type}_address_domain"
+            type_domains.append(getattr(self, method_name)())
+        return expression.AND([base_domain, expression.OR(type_domains)])

--- a/vuestorefront/models/sale_order.py
+++ b/vuestorefront/models/sale_order.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def prepare_vsf_vals(self, data):
+        # Only used for current session user current order.
+        self.ensure_one()
+        vals = {}
+        if "client_order_ref" in data:
+            vals["client_order_ref"] = data["client_order_ref"]
+        return vals

--- a/vuestorefront/tests/__init__.py
+++ b/vuestorefront/tests/__init__.py
@@ -1,1 +1,7 @@
-from . import test_product, test_public_category, test_query_product
+from . import (
+    test_product,
+    test_public_category,
+    test_query_product,
+    test_mutate_shop,
+    test_mutate_payment,
+)

--- a/vuestorefront/tests/common.py
+++ b/vuestorefront/tests/common.py
@@ -9,14 +9,28 @@ class TestVuestorefrontCommon(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.Website = cls.env["website"]
+        cls.ProductProduct = cls.env["product.product"]
+        cls.ResPartner = cls.env["res.partner"]
+        cls.PaymentTransaction = cls.env['payment.transaction']
+        cls.SaleOrder = cls.env["sale.order"]
+        cls.SaleOrderLine = cls.env["sale.order.line"]
         cls.graphene_client = Client(schema)
         cls.InvalidateCache = cls.env['invalidate.cache']
+        cls.user_portal = cls.env.ref("base.demo_user0")
+        cls.partner_portal = cls.user_portal.partner_id
         cls.public_category_desks = cls.env.ref('website_sale.public_category_desks')
         cls.public_category_components = cls.env.ref(
             'website_sale.public_category_desks_components'
         )
         cls.public_category_bins = cls.env.ref('website_sale.public_category_bins')
-        cls.product_tmpl_bin = cls.env.ref('product.product_product_9_product_template')
+        cls.product_bin = cls.env.ref("product.product_product_9")
+        cls.product_tmpl_bin = cls.product_bin.product_tmpl_id
+        cls.country_lt = cls.env.ref("base.lt")
+        cls.website_1 = cls.env.ref("website.default_website")
+        cls.payment_acquirer_transfer = cls.env.ref(
+            'payment.payment_acquirer_transfer'
+        )
 
     def execute(self, query, **kw):
         res = self.graphene_client.execute(query, context={"env": self.env}, **kw)
@@ -27,3 +41,61 @@ class TestVuestorefrontCommon(SavepointCase):
                 "GraphQL query returned error: {}".format(repr(res["errors"]))
             )
         return res.get("data")
+
+
+class TestVuestorefrontSaleCommon(TestVuestorefrontCommon):
+    """Common class to have patched active sale order for portal user."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        (
+            cls.partner_invoice_1,
+            cls.partner_delivery_1,
+            cls.partner_other_1,
+        ) = cls.ResPartner.create(
+            [
+                {
+                    "name": "Partner Invoice Address",
+                    "street": "invoice 1",
+                    "type": "invoice",
+                    "parent_id": cls.partner_portal.id,
+                },
+                {
+                    "name": "Partner Delivery Address",
+                    "street": "delivery 1",
+                    "type": "delivery",
+                    "parent_id": cls.partner_portal.id,
+                },
+                {
+                    "name": "Partner Other Address",
+                    "street": "other 1",
+                    "type": "other",
+                    "parent_id": cls.partner_portal.id,
+                },
+            ]
+        )
+
+        cls.sale_1 = cls.SaleOrder.create(
+            {
+                "partner_id": cls.partner_portal.id,
+                "partner_invoice_id": cls.partner_invoice_1.id,
+                "partner_shipping_id": cls.partner_delivery_1.id,
+            }
+        )
+        cls.sale_1_line_1 = cls.SaleOrderLine.create({
+            "product_id": cls.product_bin.id,
+            "product_uom_qty": 10,
+            "order_id": cls.sale_1.id,
+        })
+        cls.Website._patch_method(
+            "sale_get_order",
+            lambda *args, **kw: cls.sale_1.with_user(cls.user_portal).sudo()
+        )
+        # To give access to portal user.
+        cls.sale_1.message_subscribe(partner_ids=[cls.partner_portal.id])
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.Website._revert_method("sale_get_order")

--- a/vuestorefront/tests/test_mutate_payment.py
+++ b/vuestorefront/tests/test_mutate_payment.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+from .common import TestVuestorefrontSaleCommon
+
+PATH_PATCH_PAYMENT_REQ = "odoo.addons.vuestorefront.schemas.payment.request"
+
+
+class TestMutatePayment(TestVuestorefrontSaleCommon):
+    @patch(PATH_PATCH_PAYMENT_REQ)
+    def test_01_mutate_pay_transfer(self, req1):
+        # WHEN
+        with self.with_user("portal"):
+            res = self.execute(
+                """
+                mutation MakePayment ($acquirerId: Int!) {
+                    makePayment(
+                        acquirerId: $acquirerId
+                    ) { id }
+                }
+                """,
+                variables={"acquirerId": self.payment_acquirer_transfer.id}
+            )
+        # THEN
+        transaction = self.PaymentTransaction.browse(
+            res["makePayment"]["id"]
+        )
+        self.assertEqual(transaction.sale_order_ids, self.sale_1)
+        self.assertEqual(self.sale_1.state, 'sent')

--- a/vuestorefront/tests/test_mutate_shop.py
+++ b/vuestorefront/tests/test_mutate_shop.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from .common import TestVuestorefrontSaleCommon
+
+PATH_PATCH_SHOP_REQ = "odoo.addons.vuestorefront.schemas.shop.request"
+
+
+class TestMutateShop(TestVuestorefrontSaleCommon):
+    @patch(PATH_PATCH_SHOP_REQ)
+    def test_01_mutate_add_to_cart(self, req1):
+        # GIVEN
+        self.sale_1.order_line.unlink()
+        # WHEN
+        with self.with_user("portal"):
+            res = self.execute(
+                """
+                mutation CartAddItem ($productId: Int!) {
+                    cartAddItem(
+                        productId: $productId
+                        quantity: 10
+                    ) {
+                        order {
+                            id
+                        }
+                    }
+                }
+                """,
+                variables={"productId": self.product_bin.id}
+            )
+        # THEN
+        self.assertEqual(res["cartAddItem"]["order"]["id"], self.sale_1.id)
+        self.assertEqual(self.sale_1.state, "draft")
+        sale_line_1 = self.sale_1.order_line
+        self.assertEqual(len(sale_line_1), 1)
+        self.assertEqual(sale_line_1.product_id, self.product_bin)
+        self.assertEqual(sale_line_1.product_uom_qty, 10)


### PR DESCRIPTION
Improving address and order schemas, to be better reusable. Order now can be updated with some data.

Can use transfer payment via VSF mutation instead of just Adyen acquirer. New mutation is intended to be used for other payments as well, once any new are implemented.