### PR TITLE
[FIX] vuestorefront: filter unpublished products

### DIFF
--- a/vuestorefront/models/product_template.py
+++ b/vuestorefront/models/product_template.py
@@ -135,9 +135,10 @@ class ProductTemplate(models.Model):
 
     @api.model
     def prepare_vsf_domain(self, search, **kwargs):
-        # Only get published products
+        # Only get sellable products.
         domains = [self.env['website'].get_current_website().sale_product_domain()]
-
+        if self.is_vsf_published_only(**kwargs):
+            domains.append([('is_published', '=', True)])
         # Filter with ids
         if kwargs.get('ids', False):
             domains.append([('id', 'in', kwargs['ids'])])
@@ -207,3 +208,8 @@ class ProductTemplate(models.Model):
                 domains.append([('attribute_line_ids.value_ids', 'in', ids)])
 
         return expression.AND(domains)
+
+    @api.model
+    def is_vsf_published_only(self, **kwargs):
+        """Check if product search is for published products only."""
+        return True

--- a/vuestorefront/schemas/product.py
+++ b/vuestorefront/schemas/product.py
@@ -130,23 +130,22 @@ class ProductQuery(graphene.ObjectType):
     @staticmethod
     def resolve_product(self, info, id=None, slug=None, barcode=None):
         env = info.context["env"]
-        Product = env["product.template"].sudo()
-
+        Product = product = env["product.template"].sudo()
+        domain = None
+        base_domain = [('is_published', '=', True)]
         if id:
-            product = Product.search([('id', '=', id)], limit=1)
+            domain = base_domain + [('id', '=', id)]
         elif slug:
-            product = Product.search([('website_slug', '=', slug)], limit=1)
+            domain = base_domain + [('website_slug', '=', slug)]
         elif barcode:
-            product = Product.search([('barcode', '=', barcode)], limit=1)
-        else:
-            product = Product
-
+            domain = base_domain + [('barcode', '=', barcode)]
+        if domain is not None:
+            product = Product.search(domain, limit=1)
         if product:
             website = env['website'].get_current_website()
             request.website = website
             if not product.can_access_from_current_website():
                 product = Product
-
         return product
 
     @staticmethod

--- a/vuestorefront/tests/common.py
+++ b/vuestorefront/tests/common.py
@@ -31,6 +31,7 @@ class TestVuestorefrontCommon(SavepointCase):
         cls.payment_acquirer_transfer = cls.env.ref(
             'payment.payment_acquirer_transfer'
         )
+        cls.product_tmpl_bin.is_published = True
 
     def execute(self, query, **kw):
         res = self.graphene_client.execute(query, context={"env": self.env}, **kw)

--- a/vuestorefront/tests/test_mutate_shop.py
+++ b/vuestorefront/tests/test_mutate_shop.py
@@ -34,3 +34,28 @@ class TestMutateShop(TestVuestorefrontSaleCommon):
         self.assertEqual(len(sale_line_1), 1)
         self.assertEqual(sale_line_1.product_id, self.product_bin)
         self.assertEqual(sale_line_1.product_uom_qty, 10)
+        # GIVEN
+        # Check if we can still query product on cart if it was
+        # unpublished after it was already in a cart.
+        self.product_bin.is_published = False
+        # WHEN
+        with self.with_user("portal"):
+            res = self.execute(
+                """
+                query getProductFromCart {
+                    cart {
+                        order {
+                            orderLines {
+                                product {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                }
+                """,
+            )
+            self.assertEqual(
+                res["cart"]["order"]["orderLines"],
+                [{"product": {"name": "Pedal Bin"}}]
+            )

--- a/vuestorefront/tests/test_query_product.py
+++ b/vuestorefront/tests/test_query_product.py
@@ -28,7 +28,26 @@ class TestQueryProduct(common.TestVuestorefrontCommon):
         # THEN
         self.assertEqual(res["products"]["products"], [{"name": "Pedal Bin"}])
 
-    def test_02_query_product_with_category_slug_is_child(self):
+    def test_02_query_product_unpublished_with_category_slug_single(self):
+        # GIVEN
+        self.product_tmpl_bin.is_published = False
+        # WHEN
+        res = self.execute(
+            """
+            query getProductTemplates($ids: [Int], $categorySlug: String) {
+                products(filter: {ids: $ids, categorySlug: $categorySlug}) {
+                    products {
+                        name
+                    }
+                }
+            }
+            """,
+            variables={"ids": self.product_tmpl_bin.ids, "categorySlug": "bins"},
+        )
+        # THEN
+        self.assertEqual(res["products"]["products"], [])
+
+    def test_03_query_product_with_category_slug_is_child(self):
         # GIVEN
         self.product_tmpl_bin.public_categ_ids |= self.public_category_components
         # WHEN
@@ -48,7 +67,7 @@ class TestQueryProduct(common.TestVuestorefrontCommon):
         # THEN
         self.assertEqual(res["products"]["products"], [{"name": "Pedal Bin"}])
 
-    def test_03_query_product_with_category_slug_is_parent(self):
+    def test_04_query_product_with_category_slug_is_parent(self):
         # GIVEN
         self.product_tmpl_bin.public_categ_ids |= self.public_category_desks
         # WHEN


### PR DESCRIPTION
We do not include unpublished products when these are searched via VSF, unless there are specific filters intended to ignore that.