### PR TITLE
[FIX] vuestorefront: vsf_active filter

### DIFF
--- a/payment_vsf/models/payment_acquirer.py
+++ b/payment_vsf/models/payment_acquirer.py
@@ -12,6 +12,7 @@ _logger = logging.getLogger(__name__)
 class PaymentAcquirer(models.Model):
     _inherit = 'payment.acquirer'
 
+    odoo_active = fields.Boolean('Active on Odoo Website?', default=True)
     vsf_active = fields.Boolean('Active on VSF?')
 
     # Configuration fields

--- a/payment_vsf/views/payment_views.xml
+++ b/payment_vsf/views/payment_views.xml
@@ -12,6 +12,7 @@
             <field name="inherit_id" ref="payment.acquirer_form"/>
             <field name="arch" type="xml">
                 <field name="website_id" position="after">
+                    <field name="odoo_active"/>
                     <field name="vsf_active"/>
                 </field>
             </field>

--- a/vuestorefront/views/payment_templates.xml
+++ b/vuestorefront/views/payment_templates.xml
@@ -9,7 +9,10 @@
         <xpath expr="//div[hasclass('card')]//t[@t-set='acquirers_count']" position="before">
             <t t-set="list_acquirers" t-value="[int(acq) for acq in acquirers]"/>
             <t t-set="acquirers" t-value="request.env['payment.acquirer'].browse(list_acquirers)"/>
-            <t t-set="acquirers" t-value="acquirers.filtered(lambda acq: not acq.vsf_active)"/>
+            <t
+                t-set="acquirers"
+                t-value="acquirers.filtered(lambda acq: acq.odoo_active)"
+            />
         </xpath>
     </template>
 


### PR DESCRIPTION
It makes no sense to filter out payment acquirers on odoo website if vsf_active is set. `vsf_active` is intended to just specify whether acquirer is available to be used for VSF and not to exclude from odoo website.