### PR TITLE
[IMP] vuestorefront: include state_message

### DIFF
--- a/vuestorefront/schemas/objects.py
+++ b/vuestorefront/schemas/objects.py
@@ -493,6 +493,7 @@ class PaymentTransaction(OdooObjectType):
     company = graphene.Field(lambda: Partner)
     customer = graphene.Field(lambda: Partner)
     state = PaymentTransactionState()
+    state_message = graphene.String()
     return_url = graphene.String()
     checkout_url = graphene.String()
 


### PR DESCRIPTION
Now allowing to query state_message from payment transaction to for example being able to see what error occurred when processing tx.