### PR TITLE
[ADD] vuestorefront: website page cache invalidate

### DIFF
--- a/vuestorefront/__manifest__.py
+++ b/vuestorefront/__manifest__.py
@@ -32,6 +32,7 @@
         'views/product_views.xml',
         'views/res_config_settings_views.xml',
         'views/website_views.xml',
+        'views/website_page.xml',
         'views/payment_templates.xml',
     ],
     'demo': [

--- a/vuestorefront/const.py
+++ b/vuestorefront/const.py
@@ -1,0 +1,4 @@
+CFG_PARAM_VSF_CACHE_ENABLE = "vsf_cache_invalidation"
+CFG_PARAM_VSF_CACHE_URL = "vsf_cache_invalidation_url"
+CFG_PARAM_VSF_CACHE_KEY = "vsf_cache_invalidation_key"
+VSF_VACHE_TIMEOUT = 5  # seconds

--- a/vuestorefront/models/__init__.py
+++ b/vuestorefront/models/__init__.py
@@ -3,6 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from . import (
     invalidate_cache,
+    ir_ui_view,
     website,
     res_partner,
     product_public_category,

--- a/vuestorefront/models/ir_ui_view.py
+++ b/vuestorefront/models/ir_ui_view.py
@@ -1,0 +1,42 @@
+from odoo import models
+
+from ..utils import format_vsf_cache_tags, invalidate_vsf_cache
+from .. import const
+
+
+# Should we use lower case? Because sending this to VSF cache using
+# params will make it lowercase anyway..
+TAG_PFX = "IUV"
+
+
+class IrUiView(models.Model):
+    _inherit = 'ir.ui.view'
+
+    def get_vsf_cache_tags(self):
+        return format_vsf_cache_tags(TAG_PFX, self.ids)
+
+    def write(self, vals):
+        res = super().write(vals)
+        self.invalidate_website_page_views_cache()
+        return res
+
+    def unlink(self):
+        self.invalidate_website_page_views_cache()
+        return super().unlink()
+
+    def invalidate_website_page_views_cache(self):
+        if not self.env['ir.config_parameter'].get_param(
+            const.CFG_PARAM_VSF_CACHE_ENABLE
+        ):
+            return False
+        views = self._get_website_page_views()
+        if views:
+            invalidate_vsf_cache(
+                self.env, views.get_vsf_cache_tags(),
+                raise_err=False,
+            )
+            return True
+        return False
+
+    def _get_website_page_views(self):
+        return self.filtered(lambda r: r.page_ids)

--- a/vuestorefront/models/website_page.py
+++ b/vuestorefront/models/website_page.py
@@ -10,6 +10,9 @@ from ..utils import get_website
 class WebsitePage(models.Model):
     _inherit = 'website.page'
 
+    def action_invalidate_vsf_cache(self):
+        return self.mapped("view_id").invalidate_website_page_views_cache()
+
     @api.model
     def prepare_vsf_domain(self, **kw):
         website = get_website(self.env)

--- a/vuestorefront/schema.py
+++ b/vuestorefront/schema.py
@@ -72,6 +72,5 @@ schema = graphene.Schema(
         mailing_list.MailingContactList,
         mailing_list.MailingListList,
         website_page.WebsitePageList,
-        website_page.WebsitePageWithContent,
     ]
 )

--- a/vuestorefront/schemas/objects.py
+++ b/vuestorefront/schemas/objects.py
@@ -772,3 +772,8 @@ class WebsitePage(OdooObjectType):
     id = graphene.Int()
     name = graphene.String()
     url = graphene.String()
+    content = graphene.String()
+
+    def resolve_content(self, info):
+        options = self.env.context.get("website_page_content_options", {})
+        return self.render_vsf_page(**options)

--- a/vuestorefront/tests/__init__.py
+++ b/vuestorefront/tests/__init__.py
@@ -2,6 +2,7 @@ from . import (
     test_user,
     test_product,
     test_public_category,
+    test_website_page_view_cache,
     test_query_product,
     test_mutate_shop,
     test_query_mutate_payment,

--- a/vuestorefront/tests/test_website_page_view_cache.py
+++ b/vuestorefront/tests/test_website_page_view_cache.py
@@ -1,0 +1,59 @@
+import requests_mock
+
+from . import common
+from .. import const
+
+VSF_CACHE_URL = "https://example.com"
+
+
+class TestWebsitePageViewCache(common.TestVuestorefrontCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.IrConfigParameter = cls.env['ir.config_parameter']
+        cls.website_page_contactus = cls.env.ref("website.contactus_page")
+        cls.view_layout = cls.env.ref("website.layout")
+        cls.IrConfigParameter.set_param(const.CFG_PARAM_VSF_CACHE_ENABLE, "True")
+        cls.IrConfigParameter.set_param(const.CFG_PARAM_VSF_CACHE_URL, VSF_CACHE_URL)
+        cls.IrConfigParameter.set_param(const.CFG_PARAM_VSF_CACHE_KEY, "abc123")
+
+    @requests_mock.Mocker()
+    def test_01_website_page_view_cache_invalidation_ok(self, m):
+        # GIVEN
+        adapter = m.get(VSF_CACHE_URL, status_code=200, text="OK")
+        # WHEN
+        self.website_page_contactus.view_id.priority = 17
+        # THEN
+        view_id = self.website_page_contactus.view_id.id
+        self.assertEqual(adapter.call_count, 1)
+        self.assertEqual(adapter.last_request.query, f"key=abc123&tags=iuv{view_id}")
+
+    @requests_mock.Mocker()
+    def test_02_website_page_view_cache_invalidation_non_page_view(self, m):
+        # GIVEN
+        adapter = m.get(VSF_CACHE_URL, status_code=200, text="OK")
+        # WHEN
+        self.view_layout.priority = 17
+        # THEN
+        self.assertEqual(adapter.call_count, 0)
+
+    @requests_mock.Mocker()
+    def test_03_website_page_view_cache_invalidation_disabled(self, m):
+        # GIVEN
+        self.IrConfigParameter.set_param(const.CFG_PARAM_VSF_CACHE_ENABLE, False)
+        adapter = m.get(VSF_CACHE_URL, status_code=200, text="OK")
+        # WHEN
+        self.website_page_contactus.view_id.priority = 17
+        # THEN
+        self.assertEqual(adapter.call_count, 0)
+
+    @requests_mock.Mocker()
+    def test_04_website_page_view_cache_invalidation_manual(self, m):
+        # GIVEN
+        adapter = m.get(VSF_CACHE_URL, status_code=200, text="OK")
+        # WHEN
+        self.website_page_contactus.action_invalidate_vsf_cache()
+        # THEN
+        view_id = self.website_page_contactus.view_id.id
+        self.assertEqual(adapter.call_count, 1)
+        self.assertEqual(adapter.last_request.query, f"key=abc123&tags=iuv{view_id}")

--- a/vuestorefront/views/website_page.xml
+++ b/vuestorefront/views/website_page.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="website_pages_form_view_inherit" model="ir.ui.view">
+        <field name="name">website.page.form.vsf.cache</field>
+        <field name="model">website.page</field>
+        <field name="inherit_id" ref="website.website_pages_form_view"/>
+        <field name="arch" type="xml">
+            <field name="view_id" position="before">
+                <!-- To move button next to view_id value -->
+                <label
+                    for="view_id"
+                    string=""
+                    class="oe_inline"
+                />
+                <div
+                    class="o_row o_row_readonly"
+                    name="div_website_page_csv_cache_invalidation"
+                >
+                    <button
+                        name="action_invalidate_vsf_cache"
+                        string="Invalidate VSF Cache"
+                        type="object"
+                    />
+                </div>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
We now send request to VSF informing when website page's view have changed. Though currently it only supports direct view changes. If some of indirect views/templates change, it won't be triggered. For that manual trigger was added in case it is needed to invalidate cache.

Also redesigned `content` returned from website.page, to be used as normal field. Options are now passed via context.