### PR TITLE
[ADD] vuestorefront: lang support

### DIFF
--- a/vuestorefront/schemas/objects.py
+++ b/vuestorefront/schemas/objects.py
@@ -774,6 +774,10 @@ class WebsitePage(OdooObjectType):
     url = graphene.String()
     content = graphene.String()
 
+    def resolve_url(self, info):
+        options = self.env.context.get("website_page_content_options", {})
+        return self.get_vsf_url(**options)
+
     def resolve_content(self, info):
         options = self.env.context.get("website_page_content_options", {})
         return self.render_vsf_page(**options)

--- a/vuestorefront/schemas/website_page.py
+++ b/vuestorefront/schemas/website_page.py
@@ -18,6 +18,7 @@ class WebsitePageList(graphene.ObjectType):
 
 class WebsitePageContentInput(graphene.InputObjectType):
     excluded_tags = graphene.List(graphene.String)
+    lang = graphene.String(description="Language Locale Code (e.g. en_US, nl_BE)")
 
 
 class WebsitePageFilterInput(graphene.InputObjectType):


### PR DESCRIPTION
Website page content can now be rendered with specified language. Though language must exist and be enabled in odoo backend, otherwise 404 will be returned instead.