### PR TITLE
[IMP] vuestorefront: website page cache

### DIFF
--- a/vuestorefront/models/invalidate_cache.py
+++ b/vuestorefront/models/invalidate_cache.py
@@ -7,6 +7,8 @@ from datetime import datetime
 import requests
 from odoo import models, fields, api
 
+from .. import const
+
 _logger = logging.getLogger(__name__)
 
 
@@ -84,8 +86,10 @@ class InvalidateCache(models.Model):
     @api.model
     def request_vsf_cache_invalidation(self):
         ICP = self.env['ir.config_parameter'].sudo()
-        url = ICP.get_param('vsf_cache_invalidation_url', False)
-        key = ICP.get_param('vsf_cache_invalidation_key', False)
+        if not ICP.get_param(const.CFG_PARAM_VSF_CACHE_ENABLE):
+            return
+        url = ICP.get_param(const.CFG_PARAM_VSF_CACHE_URL)
+        key = ICP.get_param(const.CFG_PARAM_VSF_CACHE_KEY)
 
         models = [
             {

--- a/vuestorefront/models/ir_ui_view.py
+++ b/vuestorefront/models/ir_ui_view.py
@@ -3,10 +3,7 @@ from odoo import models
 from ..utils import format_vsf_cache_tags, invalidate_vsf_cache
 from .. import const
 
-
-# Should we use lower case? Because sending this to VSF cache using
-# params will make it lowercase anyway..
-TAG_PFX = "IUV"
+TAG_PFX = "iuv"
 
 
 class IrUiView(models.Model):
@@ -25,8 +22,14 @@ class IrUiView(models.Model):
         return super().unlink()
 
     def invalidate_website_page_views_cache(self):
-        if not self.env['ir.config_parameter'].get_param(
-            const.CFG_PARAM_VSF_CACHE_ENABLE
+        ICP = self.env['ir.config_parameter'].sudo()
+        # TODO: for now we are checking URL/KEY instead of
+        # CFG_PARAM_VSF_CACHE_ENABLE here, so we could use website page
+        # cache when the rest of caching is disabled. Normally all
+        # caching should be enabled.
+        if (
+            not ICP.get_param(const.CFG_PARAM_VSF_CACHE_URL)
+            or not ICP.get_param(const.CFG_PARAM_VSF_CACHE_KEY)
         ):
             return False
         views = self._get_website_page_views()

--- a/vuestorefront/models/website.py
+++ b/vuestorefront/models/website.py
@@ -5,6 +5,8 @@
 import requests
 from odoo import models, fields, api
 
+from .. import const
+
 
 class Website(models.Model):
     _inherit = 'website'
@@ -49,8 +51,10 @@ class WebsiteRewrite(models.Model):
 
     def _vsf_request_cache_invalidation(self):
         ICP = self.env['ir.config_parameter'].sudo()
-        url = ICP.get_param('vsf_cache_invalidation_url', False)
-        key = ICP.get_param('vsf_cache_invalidation_key', False)
+        if not ICP.get_param(const.CFG_PARAM_VSF_CACHE_ENABLE):
+            return
+        url = ICP.get_param(const.CFG_PARAM_VSF_CACHE_URL)
+        key = ICP.get_param(const.CFG_PARAM_VSF_CACHE_KEY)
 
         if url and key:
             try:

--- a/vuestorefront/schemas/objects.py
+++ b/vuestorefront/schemas/objects.py
@@ -773,6 +773,7 @@ class WebsitePage(OdooObjectType):
     name = graphene.String()
     url = graphene.String()
     content = graphene.String()
+    content_cache_tag = graphene.String()
 
     def resolve_url(self, info):
         options = self.env.context.get("website_page_content_options", {})
@@ -781,3 +782,6 @@ class WebsitePage(OdooObjectType):
     def resolve_content(self, info):
         options = self.env.context.get("website_page_content_options", {})
         return self.render_vsf_page(**options)
+
+    def resolve_content_cache_tag(self, info):
+        return self.view_id.get_vsf_cache_tags()

--- a/vuestorefront/tests/test_query_website_page.py
+++ b/vuestorefront/tests/test_query_website_page.py
@@ -81,6 +81,7 @@ class TestQueryWebsitePage(common.TestVuestorefrontCommon, HttpCaseCommon):
                     name
                     url
                     content
+                    contentCacheTag
                 }
             }
             """,
@@ -101,6 +102,7 @@ class TestQueryWebsitePage(common.TestVuestorefrontCommon, HttpCaseCommon):
             {
                 "name": "Contact Us",
                 "url": "/en_US/contactus",
+                "contentCacheTag": f"iuv{self.website_page_contactus.view_id.id}"
             }
         )
         self.assertIn('</html>', content)

--- a/vuestorefront/tests/test_website_page_view_cache.py
+++ b/vuestorefront/tests/test_website_page_view_cache.py
@@ -40,7 +40,10 @@ class TestWebsitePageViewCache(common.TestVuestorefrontCommon):
     @requests_mock.Mocker()
     def test_03_website_page_view_cache_invalidation_disabled(self, m):
         # GIVEN
-        self.IrConfigParameter.set_param(const.CFG_PARAM_VSF_CACHE_ENABLE, False)
+        # NOTE. Normally to disable it, we would need to disable
+        # CFG_PARAM_VSF_CACHE_ENABLE option, but for now we want to use
+        # website page cache separately from the rest of the caching..
+        self.IrConfigParameter.set_param(const.CFG_PARAM_VSF_CACHE_URL, False)
         adapter = m.get(VSF_CACHE_URL, status_code=200, text="OK")
         # WHEN
         self.website_page_contactus.view_id.priority = 17


### PR DESCRIPTION
Allowing to use website page cache without enabling cache for the rest of odoo as a workaround before the rest of cache is properly implemented.

Now we also allow to query website page content's cache key (tag) so VSF would know the reference.